### PR TITLE
Send the expected DSCP codepoints

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -102,7 +102,7 @@ func main() {
     for _, mark := range dscp_map {
 		token.DSCP = mark.Value
 
-		if err := ipv4.NewConn(conn).SetTOS(token.DSCP); err != nil {
+		if err := ipv4.NewConn(conn).SetTOS(token.DSCP << 2); err != nil {
 			fmt.Printf("Some error %v", err)
 			return
 		}


### PR DESCRIPTION
The SetTOS call makes a call to set the IP_TOS socket option (https://github.com/golang/net/blob/master/ipv4/sys_linux.go#L20), which sets the TOS field. The DSCP field occupies the higher 6 bits of this field, so values need to be left shifted by 2 in order to be the expected value.

Double check this with Wireshark because I haven't actually run the code, just spotted it.